### PR TITLE
Configure secret values as options instead of commands

### DIFF
--- a/src/cmds/secrets_cmds/add.js
+++ b/src/cmds/secrets_cmds/add.js
@@ -35,8 +35,6 @@ exports.handler = async args => {
   const endpoint = args.endpoint || 'https://api.statickit.com';
   const userAgent = `@statickit/cli@${version}`;
 
-  console.log(args);
-
   if (!deployKey) {
     messages.authRequired();
     process.exitCode = 1;

--- a/src/cmds/secrets_cmds/add.js
+++ b/src/cmds/secrets_cmds/add.js
@@ -15,7 +15,7 @@ const humanizeField = name => {
   }
 };
 
-exports.command = 'add <name> <value>';
+exports.command = 'add <name> [value]';
 exports.desc = 'Adds a secret';
 
 exports.builder = yargs => {
@@ -34,6 +34,8 @@ exports.handler = async args => {
   const deployKey = deploy.getDeployKey(args);
   const endpoint = args.endpoint || 'https://api.statickit.com';
   const userAgent = `@statickit/cli@${version}`;
+
+  console.log(args);
 
   if (!deployKey) {
     messages.authRequired();

--- a/src/cmds/secrets_cmds/update.js
+++ b/src/cmds/secrets_cmds/update.js
@@ -15,7 +15,7 @@ const humanizeField = name => {
   }
 };
 
-exports.command = 'update <name> <value>';
+exports.command = 'update <name> [value]';
 exports.desc = 'Updates a secret value';
 
 exports.builder = yargs => {


### PR DESCRIPTION
When your secret contains dashes, `yargs` parses it incorrectly as an argument. Running something like: 

```
statickit secrets add example-secret-api '-secret-with-dash'
```
Returns this:

```javascript
{
  _: [ 'secrets', 'add', 'example-secret-api' ],
  s: true,
  e: [ true, true ],
  c: true,
  r: true,
  t: '-with-dash',
  '$0': 'statickit'
}
```
When using it as an option, it will parse as a string:

```bash
statickit secrets add example-secret-api --value='-secret-with-dash'
```
Returns:

```javascript
{
  _: [ 'secrets', 'add' ],
  value: '-secret-with-dash',
  '$0': 'statickit',
  name: 'example-secret-api'
 }
```